### PR TITLE
Fix contact form submission by adding HTMX to public layout

### DIFF
--- a/views/contact/index.templ
+++ b/views/contact/index.templ
@@ -30,6 +30,8 @@ templ Index(c echo.Context) {
 								<form
 									id="contact-form"
 									class="space-y-6"
+									method="post"
+									action="/contact/submit"
 									hx-post="/contact/submit"
 									hx-target="#contact-form-messages"
 									hx-swap="innerHTML"

--- a/views/layout/base.templ
+++ b/views/layout/base.templ
@@ -52,6 +52,8 @@ templ Base(c echo.Context, meta Meta) {
 			<!-- Alpine.js for interactivity -->
 			<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
 			<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+			<!-- HTMX for dynamic content -->
+			<script src="https://unpkg.com/htmx.org@1.9.10"></script>
 			<!-- Load Cart JavaScript -->
 			<script src="/public/js/cart.js?v=3"></script>
 			<!-- Load Shipping JavaScript -->


### PR DESCRIPTION
## Summary

Fixes a critical bug where the contact form was not saving submissions to the database or sending emails in production.

**Root Cause:**
- Contact form uses HTMX (`hx-post="/contact/submit"`) but had no fallback `method` attribute
- HTMX was only loaded in admin layout, not the public base layout
- Without HTMX, the browser defaulted to GET submission to current URL (`/contact`)
- Form data appeared in query parameters instead of POST body
- GET request rendered the page instead of triggering the POST handler that saves to DB and sends email

**Changes:**
- Added HTMX v1.9.10 script to public base layout (`views/layout/base.templ`)
- Added fallback `method="post"` and `action="/contact/submit"` to contact form
- Ensures graceful degradation if HTMX fails to load

**Impact:**
- Contact form now properly submits via POST to `/contact/submit`
- Submissions save to database correctly
- Email notifications sent (once Brevo DNS is configured)
- HTMX loaded efficiently with no duplication across public pages

## Test plan

- [ ] Visit `/contact` page locally
- [ ] Fill out contact form with test data
- [ ] Submit the form
- [ ] Verify submission appears in admin contacts list
- [ ] Verify form clears after successful submission (HTMX behavior)
- [ ] Test with JavaScript disabled to verify fallback works
- [ ] Verify no console errors related to HTMX

🤖 Generated with [Claude Code](https://claude.com/claude-code)